### PR TITLE
Update the tag of Iodide for the Python example

### DIFF
--- a/python.html
+++ b/python.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Python - iodide</title>
-<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180420.css">
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180605.css">
 </head>
 <body>
 <script id="jsmd" type="text/jsmd">
@@ -264,6 +264,6 @@ A couple things that already work that will be coming to this example notebook s
 %% js
 </script>
 <div id='page'></div>
-<script src='https://iodide.io/dist/iodide.pyodide-20180420.js'></script>
+<script src='https://iodide.io/dist/iodide.pyodide-20180605.js'></script>
 </body>
 </html>

--- a/python.html
+++ b/python.html
@@ -118,9 +118,7 @@ For example, say we had the following Python function that we wanted to call fro
 
 %% code {"language":"py"}
 # python
-def square(x, integer=False):
-  if integer:
-    x = int(x)
+def square(x):
   return x * x
 
 %% md
@@ -129,14 +127,14 @@ Since calling conventions are a bit different in Python than in Javascript, all 
 %% js
 // javascript
 var square = pyodide.pyimport("square")
-square([2.5], {integer: true})
+square(2.5)
 
 %% md
 This is equivalent to the following Python syntax:
 
 %% code {"language":"py"}
 # python
-square(2.5, integer=True)
+square(2.5)
 
 %% md
 You can also get the attributes of objects in a similar way.  Say we had an instance of the following Python custom class:


### PR DESCRIPTION
This updates the version of Iodide used for the Python example.

It also updates the syntax to one of the examples to be current with pyodide master.